### PR TITLE
fix: saveToken시 토큰이 제대로 세팅되지 않는 이슈

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,6 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AuthProvider from "@/AuthProvider";
 import { ErrorBoundary } from "react-error-boundary";
-import Skeleton from "@/screens/Skeleton";
 import ErrorPage from "@/screens/ErrorPage";
 
 export default function App() {

--- a/src/utils/service/auth.ts
+++ b/src/utils/service/auth.ts
@@ -12,10 +12,9 @@ export const saveTokens = async (
 ) => {
   try {
     await AsyncStorage.setItem(TOKEN_KEYS.ACCESS, accessToken);
-    API.defaults.headers.common['Authorization'] = accessToken;
+    API.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
     if (refreshToken) {
       await AsyncStorage.setItem(TOKEN_KEYS.REFRESH, refreshToken);
-      API.defaults.headers.common['Authorization'] = refreshToken;
     }
   } catch (error) {
     console.error("Error saving tokens:", error);
@@ -24,7 +23,7 @@ export const saveTokens = async (
 
 export const getAccessToken = async () => {
   try {
-    return AsyncStorage.getItem(TOKEN_KEYS.ACCESS);
+    return API.defaults.headers.common['Authorization'] || AsyncStorage.getItem(TOKEN_KEYS.ACCESS);
   } catch (error) {
     console.error("Error getting access token:", error);
     return null;


### PR DESCRIPTION
## 📌 관련 이슈
- 첫 회원가입 시 saveToken 함수 실행 시 'Bearer ' 값이 빠진 상태로 API 객체 헤더에 셋팅됨.
<br><br>

## 🛠️ 작업 내용
- saveToken 함수 실행 시 토큰 값 제대로 셋팅되도록 수정
- getToken 시 우선 API 객체(메모리)에 있는 값 먼저 보도록 수정
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
