### PR TITLE
feat: 앱 진입 시에 토큰 있는 경우 유저 정보 불러오도록 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,10 @@ import i18n from '@/i18n';
 import Router from '@/navigation/router';
 import { AuthProvider } from '@/provider';
 import ErrorPage from '@/screens/ErrorPage';
+import { createNavigationContainerRef, NavigationContainer } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const navigationRef = createNavigationContainerRef();
 
 export default function App() {
   const queryClient = new QueryClient();
@@ -18,7 +21,9 @@ export default function App() {
           <Suspense fallback={<></>}>
             <GestureHandlerRootView>
               <AuthProvider>
-                <Router />
+                <NavigationContainer ref={navigationRef}>
+                  <Router />
+                </NavigationContainer>
               </AuthProvider>
             </GestureHandlerRootView>
           </Suspense>

--- a/src/api/API.ts
+++ b/src/api/API.ts
@@ -1,10 +1,5 @@
-import { Alert } from 'react-native';
-import i18n from '@/i18n';
-import { resetToOnboarding } from '@/navigation/navigationRef';
 import axios from 'axios';
 import Constants from 'expo-constants';
-import * as SecureStore from 'expo-secure-store';
-import { TOKEN_KEYS } from '@/utils';
 
 const BASE_URL = Constants?.expoConfig?.extra?.BASE_URL || '';
 
@@ -12,56 +7,5 @@ export const API = axios.create({
   baseURL: BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 });
-
-const reissueTokens = async (refreshToken: string) => {
-  const response = await API.post(`${BASE_URL}/auth/reissue`, { refreshToken });
-  return response.data;
-};
-
-const showErrorModal = (messageKey: string) => {
-  Alert.alert(
-    i18n.t('error:title'),
-    i18n.t(`error:${messageKey}`),
-    [{ text: i18n.t('common:confirm'), style: 'default' }],
-    { cancelable: true }
-  );
-};
-
-API.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    if (!error.response) {
-      showErrorModal('network');
-      return Promise.reject(error);
-    }
-
-    const errorCode = error.response?.data?.code;
-
-    if (error.response?.status === 401 && errorCode === 3002 && !error.config._retry) {
-      error.config._retry = true;
-      try {
-        const refreshToken = await SecureStore.getItemAsync(TOKEN_KEYS.REFRESH);
-        if (!refreshToken) {
-          throw new Error('Refresh token not found');
-        }
-        const { accessToken, refreshToken: newRefreshToken } = await reissueTokens(refreshToken);
-
-        const finalRefreshToken = newRefreshToken || refreshToken;
-        await SecureStore.setItemAsync(TOKEN_KEYS.ACCESS, accessToken);
-        await SecureStore.setItemAsync(TOKEN_KEYS.REFRESH, finalRefreshToken);
-        error.config.headers.common.Authorization = `Bearer ${accessToken}`;
-        return API(error.config);
-      } catch (reissueError) {
-        await SecureStore.deleteItemAsync(TOKEN_KEYS.ACCESS);
-        await SecureStore.deleteItemAsync(TOKEN_KEYS.REFRESH);
-        delete API.defaults.headers.common['Authorization'];
-        resetToOnboarding();
-        showErrorModal('tokenExpired');
-        return Promise.reject(reissueError);
-      }
-    }
-    return Promise.reject(error);
-  }
-);
 
 export default API;

--- a/src/api/AuthRepository.ts
+++ b/src/api/AuthRepository.ts
@@ -48,6 +48,11 @@ class AuthRepository {
     const { data } = await API.put(`/certification/refresh`);
     return data;
   }
+
+  async reissueToken(refreshToken: string) {
+    const { data } = await API.post('/auth/reissue', { refreshToken });
+    return data;
+  }
 }
 
 export default new AuthRepository();

--- a/src/api/UserRepository.ts
+++ b/src/api/UserRepository.ts
@@ -25,7 +25,7 @@ class UserRepository {
   }
 
   async delete() {
-    const { data } = await API.delete(`/users/delete`);
+    const { data } = await API.delete(`/users`);
     return data;
   }
 }

--- a/src/navigation/navigationRef.tsx
+++ b/src/navigation/navigationRef.tsx
@@ -1,16 +1,4 @@
 import { Feed, Room } from '@/types';
-import { createNavigationContainerRef } from '@react-navigation/native';
-
-export const navigationRef = createNavigationContainerRef();
-
-export const resetToOnboarding = () => {
-  if (navigationRef.isReady()) {
-    navigationRef.reset({
-      index: 0,
-      routes: [{ name: 'Onboarding' }],
-    });
-  }
-};
 
 export type OnboardingStackParamList = {
   OnboardingWelcome: undefined;

--- a/src/navigation/router.tsx
+++ b/src/navigation/router.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import SplashScreen from '@/screens/SplashScreen';
 import ChatRoomScreen from '@/screens/chat/ChatRoomScreen';
@@ -29,9 +29,10 @@ import EmailScreen from '@/screens/verification/EmailScreen';
 import EmailVerificationScreen from '@/screens/verification/EmailVerificationScreen';
 import StudentIdCardCompleteScreen from '@/screens/verification/StudentIdCompleteScreen';
 import StudentIdCardUploadScreen from '@/screens/verification/StudentIdUploadScreen';
-import { useModalStore } from '@/store';
+import { useModalStore, useUserStore } from '@/store';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import {
+  createNavigationContainerRef,
   getFocusedRouteNameFromRoute,
   NavigationContainer,
   useNavigation,
@@ -47,7 +48,6 @@ import {
   ChatStackParamList,
   FeedStackParamList,
   MyPageStackParamList,
-  navigationRef,
   OnboardingStackParamList,
 } from './navigationRef';
 
@@ -57,6 +57,8 @@ const OnboardingStack = createNativeStackNavigator<OnboardingStackParamList>();
 const FeedStack = createNativeStackNavigator<FeedStackParamList>();
 const ChatStack = createNativeStackNavigator<ChatStackParamList>();
 const MyPageStack = createNativeStackNavigator<MyPageStackParamList>();
+
+export const navigationRef = createNavigationContainerRef();
 
 function TabNavigator() {
   const { t } = useTranslation('common');
@@ -242,9 +244,20 @@ function MyPageNavigator() {
 export default function Router() {
   const modalVisible = useModalStore((state) => state.visible.studentCertification);
   const handleModalClose = useModalStore((state) => state.handleClose);
+  const isAuthenticated = useUserStore((state) => state.isAuthenticated);
+  // TODO: 타입 수정 필요..
+  const navigation = useNavigation<any>();
 
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Onboarding' }],
+      });
+    }
+  }, [isAuthenticated]);
   return (
-    <NavigationContainer ref={navigationRef}>
+    <>
       <Stack.Navigator screenOptions={{ headerShown: false, gestureEnabled: false }}>
         <Stack.Screen name="Splash" component={SplashScreen} />
         <Stack.Screen name="Onboarding" component={OnboardingNavigator} />
@@ -257,6 +270,6 @@ export default function Router() {
         visible={modalVisible}
         onClose={() => handleModalClose('studentCertification')}
       />
-    </NavigationContainer>
+    </>
   );
 }

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -18,6 +18,7 @@ interface CustomJwtPayload extends JwtPayload {
 export default function AuthProvider({ children }: Props) {
   const [loading, setLoading] = useState(false);
   const [initLoading, setInitLoading] = useState(false);
+  const isAuthenticated = useUserStore((state) => state.isAuthenticated);
   const updateUser = useUserStore((state) => state.update);
   const initAuth = async () => {
     // 토큰이 있으면 API 헤더에 추가. 없으면 그냥 통과
@@ -37,7 +38,7 @@ export default function AuthProvider({ children }: Props) {
     setInitLoading(true);
     initAuth();
     setInitLoading(false);
-  }, []);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     setLoading(true);

--- a/src/provider/AuthProvider.tsx
+++ b/src/provider/AuthProvider.tsx
@@ -1,9 +1,12 @@
-import { API, UserRepository } from '@/api';
-import SplashScreen from '@/screens/SplashScreen';
+import { useEffect, useState } from 'react';
+import { View, Image } from 'react-native';
+import { API, AuthRepository, UserRepository } from '@/api';
 import { TokenService } from '@/service';
 import { useUserStore } from '@/store';
 import { useQuery } from '@tanstack/react-query';
+import * as SecureStore from 'expo-secure-store';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import { showErrorModal, TOKEN_KEYS } from '@/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -14,6 +17,8 @@ interface CustomJwtPayload extends JwtPayload {
 }
 
 export default function AuthProvider({ children }: Props) {
+  const [loading, setLoading] = useState(false);
+  const isAuthenticated = useUserStore((state) => state.isAuthenticated);
   const updateUser = useUserStore((state) => state.update);
   const initAuth = async () => {
     // 토큰이 있으면 API 헤더에 추가. 없으면 그냥 통과
@@ -29,11 +34,11 @@ export default function AuthProvider({ children }: Props) {
     const token: CustomJwtPayload = jwtDecode(accessToken);
     const userId = token.studentId;
     const user = await UserRepository.get({ id: userId });
-    updateUser(user);
+    updateUser({ ...user, isAuthenticated: true });
     return user;
   };
 
-  const { data: accessToken, isLoading: authLoading } = useQuery({
+  const { data: accessToken, isLoading: initAuthLoading } = useQuery({
     queryKey: ['auth'],
     queryFn: initAuth,
     networkMode: 'always',
@@ -42,12 +47,57 @@ export default function AuthProvider({ children }: Props) {
 
   const { isLoading: getUserLoading } = useQuery({
     queryKey: ['user'],
-    queryFn: async () => await getUser(accessToken as string),
-    enabled: !!accessToken,
+    queryFn: () => getUser(accessToken as string),
+    enabled: isAuthenticated,
     throwOnError: true,
     retryDelay: 1000,
   });
 
-  if (authLoading || getUserLoading) return <SplashScreen />;
+  useEffect(() => {
+    setLoading(true);
+    API.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        if (!error.response) {
+          showErrorModal('network');
+          return Promise.reject(error);
+        }
+        const errorCode = error.response?.data?.code;
+
+        if (error.response?.status === 401 && errorCode === 3002 && !error.config._retry) {
+          error.config._retry = true;
+          try {
+            const refreshToken = await SecureStore.getItemAsync(TOKEN_KEYS.REFRESH);
+            if (!refreshToken) {
+              throw new Error('Refresh token not found');
+            }
+            const { accessToken, refreshToken: newRefreshToken } =
+              await AuthRepository.reissueToken(refreshToken);
+
+            await SecureStore.setItemAsync(TOKEN_KEYS.ACCESS, accessToken);
+            await SecureStore.setItemAsync(TOKEN_KEYS.REFRESH, newRefreshToken);
+            error.config.headers.common.Authorization = `Bearer ${accessToken}`;
+            return API(error.config);
+          } catch (reissueError) {
+            await SecureStore.deleteItemAsync(TOKEN_KEYS.ACCESS);
+            await SecureStore.deleteItemAsync(TOKEN_KEYS.REFRESH);
+            delete API.defaults.headers.common['Authorization'];
+            updateUser({ isAuthenticated: false });
+            showErrorModal('tokenExpired');
+            return Promise.reject(reissueError);
+          }
+        }
+        return Promise.reject(error);
+      }
+    );
+    setLoading(false);
+  }, []);
+
+  if (initAuthLoading || getUserLoading || loading)
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Image source={require('@assets/images/splash.png')} className="h-full w-full" />
+      </View>
+    );
   return <>{children}</>;
 }

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { View, TouchableOpacity, Image } from 'react-native';
 import { AuthRepository, UserRepository } from '@/api';
 import { InnerLayout, Layout, MyText } from '@/components';
-import { MyPageStackParamList, resetToOnboarding } from '@/navigation/navigationRef';
+import { MyPageStackParamList } from '@/navigation/navigationRef';
 import { TokenService } from '@/service';
 import { useUserStore } from '@/store';
 import LogoIcon from '@assets/icons/logo.svg';
@@ -35,6 +35,7 @@ export default function MyPageScreen({ navigation }: MyPageScreenProps) {
   const name = useUserStore((state) => state.name);
   const country = useUserStore((state) => state.country);
   const university = useUserStore((store) => store.university);
+  const update = useUserStore((state) => state.update);
 
   const quickMenuItems = [
     {
@@ -64,7 +65,7 @@ export default function MyPageScreen({ navigation }: MyPageScreenProps) {
       onPress: async () => {
         await UserRepository.delete();
         await TokenService.remove();
-        resetToOnboarding();
+        update({ isAuthenticated: false });
       },
     },
     {
@@ -134,7 +135,7 @@ export default function MyPageScreen({ navigation }: MyPageScreenProps) {
         </View>
 
         <View className="mt-4 bg-white">
-          {settingsItems.map((item, index) => (
+          {settingsItems.map((item) => (
             <Fragment key={item.key}>
               <SettingItem label={item.label} onPress={item.onPress} />
             </Fragment>

--- a/src/screens/onboarding/InterestSelectScreen.tsx
+++ b/src/screens/onboarding/InterestSelectScreen.tsx
@@ -1,13 +1,13 @@
-import { UserRepository } from '@/api';
-import { Button, Chip, Heading, InnerLayout, Layout, MyText } from '@/components';
-import { MyPageStackParamList, OnboardingStackParamList } from '@/navigation/navigationRef';
-import { TokenService } from '@/service';
-import { useOnboardingStore } from '@/store';
-import { NativeStackNavigationProp, NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useState } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
+import { UserRepository } from '@/api';
+import { Button, Chip, Heading, InnerLayout, Layout, MyText } from '@/components';
+import { MyPageStackParamList, OnboardingStackParamList } from '@/navigation/navigationRef';
+import { TokenService } from '@/service';
+import { useOnboardingStore, useUserStore } from '@/store';
+import { NativeStackNavigationProp, NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { InterestID } from '@/utils';
 import { INTEREST_CATEGORIES, INTEREST_ICONS, logError } from '@/utils';
 
@@ -25,6 +25,7 @@ const MAX_SELECT = 8;
 function InterestSelectScreen({ navigation, route }: InterestSelectProps) {
   const { t } = useTranslation(['onboarding', 'interests']);
   const { updateOnboardingData, ...onboardingData } = useOnboardingStore();
+  const update = useUserStore((state) => state.update);
 
   const isEditMode =
     'params' in route && route.params && 'isEditMode' in route.params
@@ -70,6 +71,7 @@ function InterestSelectScreen({ navigation, route }: InterestSelectProps) {
           interests,
         });
         await TokenService.save(accessToken, refreshToken);
+        update({ isAuthenticated: true });
         const onboardNav = navigation as NativeStackNavigationProp<
           OnboardingStackParamList,
           'OnboardingInterestSelect'

--- a/src/screens/onboarding/NotificationScreen.tsx
+++ b/src/screens/onboarding/NotificationScreen.tsx
@@ -1,24 +1,29 @@
-import AlertIcon from '@assets/icons/alert.svg';
-import * as Notifications from 'expo-notifications';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
-import { useOnboardingStore } from '@/store';
 import { Button, Heading, HeadingDescription, InnerLayout, Layout, MyText } from '@/components';
 import { OnboardingStackParamList } from '@/navigation/navigationRef';
+import { useOnboardingStore, useUserStore } from '@/store';
+import AlertIcon from '@assets/icons/alert.svg';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as Notifications from 'expo-notifications';
 
 type OnboardingNotificationScreenProps = NativeStackScreenProps<
   OnboardingStackParamList,
   'OnboardingNotification'
 >;
 
-export default function NotificationScreen({ navigation, route }: OnboardingNotificationScreenProps) {
+export default function NotificationScreen({
+  navigation,
+  route,
+}: OnboardingNotificationScreenProps) {
   const { t } = useTranslation('onboarding');
   const { updateOnboardingData } = useOnboardingStore();
+  const update = useUserStore((state) => state.update);
   const isExistingMember = route.params?.isExistingMember;
 
   const handleNavigate = () => {
     if (isExistingMember) {
+      update({ isAuthenticated: true });
       navigation.reset({ index: 0, routes: [{ name: 'Tab' }] });
     } else {
       navigation.replace('OnboardingUniversitySelect');

--- a/src/screens/onboarding/PhoneVerificationScreen.tsx
+++ b/src/screens/onboarding/PhoneVerificationScreen.tsx
@@ -1,15 +1,27 @@
-import { Send } from 'lucide-react-native';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
-import { useOnboardingStore } from '@/store';
-import { useTimer } from '@/hooks';
-import { formatPhone, logError } from '@/utils';
 import { AuthRepository } from '@/api';
-import { TokenService } from '@/service';
-import { ErrorMessage, FooterLayout, Heading, HeadingDescription, InnerLayout, KeyboardLayout, Label, Layout, LinkText, MyText, OTPInput } from '@/components';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import {
+  ErrorMessage,
+  FooterLayout,
+  Heading,
+  HeadingDescription,
+  InnerLayout,
+  KeyboardLayout,
+  Label,
+  Layout,
+  LinkText,
+  MyText,
+  OTPInput,
+} from '@/components';
+import { useTimer } from '@/hooks';
 import { OnboardingStackParamList } from '@/navigation/navigationRef';
+import { TokenService } from '@/service';
+import { useOnboardingStore, useUserStore } from '@/store';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Send } from 'lucide-react-native';
+import { formatPhone, logError } from '@/utils';
 
 const VERIFICATION_EXPIRE_SECONDS = 180;
 
@@ -18,9 +30,13 @@ type OnboardingPhoneVerificationScreenProps = NativeStackScreenProps<
   'OnboardingPhoneVerification'
 >;
 
-export default function PhoneVerificationScreen({ navigation, route }: OnboardingPhoneVerificationScreenProps) {
+export default function PhoneVerificationScreen({
+  navigation,
+  route,
+}: OnboardingPhoneVerificationScreenProps) {
   const { t } = useTranslation('onboarding');
   const { updateOnboardingData } = useOnboardingStore();
+  const update = useUserStore((state) => state.update);
 
   const formattedPhone = route.params.phone;
   const phoneNumber = formatPhone.removeHyphen(formattedPhone);
@@ -30,7 +46,7 @@ export default function PhoneVerificationScreen({ navigation, route }: Onboardin
 
   const { timeLeft, isExpired, restart } = useTimer({
     seconds: VERIFICATION_EXPIRE_SECONDS,
-    onExpire: () => { },
+    onExpire: () => {},
   });
 
   const resetVerification = () => {
@@ -55,6 +71,7 @@ export default function PhoneVerificationScreen({ navigation, route }: Onboardin
       updateOnboardingData({ phoneNumber });
       if (data.status === 'EXISTING_MEMBER') {
         await TokenService.save(data.accessToken, data.refreshToken);
+        update({ isAuthenticated: true });
       }
       navigation.replace('OnboardingNotification', {
         isExistingMember: data.status === 'EXISTING_MEMBER',

--- a/src/screens/verification/StudentIdCompleteScreen.tsx
+++ b/src/screens/verification/StudentIdCompleteScreen.tsx
@@ -1,15 +1,18 @@
 import { useTranslation } from 'react-i18next';
 import { View } from 'react-native';
 import { Button, Heading, HeadingDescription, Layout } from '@/components';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { FeedStackParamList } from '@/navigation/navigationRef';
+import { useUserStore } from '@/store';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 type EmailVerificationScreenProps = NativeStackScreenProps<FeedStackParamList, 'StudentIdComplete'>;
 
 export default function StudentIdCardCompleteScreen({ navigation }: EmailVerificationScreenProps) {
   const { t } = useTranslation('');
+  const update = useUserStore((state) => state.update);
 
   const handleNavigationButton = () => {
+    update({ isAuthenticated: true });
     navigation.reset({
       index: 0,
       routes: [{ name: 'FeedHome' }],

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -13,6 +13,7 @@ type UserState = {
   isCertificated: boolean;
   isStudentIdCardRequested: boolean;
   isKorean: boolean;
+  isAuthenticated: boolean;
 };
 
 type UserAction = {
@@ -32,6 +33,7 @@ export const useUserStore = create(
     isCertificated: false,
     isStudentIdCardRequested: false,
     isKorean: false,
+    isAuthenticated: false,
 
     update: (user) =>
       set((state) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './error';
 export * from './formData';
 export * from './deviceCheck';
 export * from './regex';
+export * from './showErrorModal';

--- a/src/utils/showErrorModal.ts
+++ b/src/utils/showErrorModal.ts
@@ -1,0 +1,11 @@
+import { Alert } from 'react-native';
+import i18n from '@/i18n';
+
+export const showErrorModal = (messageKey: string) => {
+  Alert.alert(
+    i18n.t('error:title'),
+    i18n.t(`error:${messageKey}`),
+    [{ text: i18n.t('common:confirm'), style: 'default' }],
+    { cancelable: true }
+  );
+};


### PR DESCRIPTION
## 📌 관련 이슈

<br><br>

## 🛠️ 작업 내용
- 앱 진입 시 엑세스 토큰 통하여 유저 정보 가져오고 & 유저 정보 set 하도록 구현
- resetToOnboarding 함수 삭제 => router.tsx 보시면 isAuthenticated가 false인 경우 온보딩 페이지로 보내게끔 작업했습니다.
- 인증 성공 / 취미 선택 완료 후 가입 성공 시, isAuthenticated true로 바꿔주고 피드 진입 / 반대의 경우 isAuthenticated false로 바꿔서 온보딩 페이지로 보냄
<br><br>

## 🎯 리뷰 포인트
- 리액트 쿼리를 쓰려다 너무 시간을 많이 허비했는데, 리액트 쿼리가 꼭 필요하지 않은 경우도 있다는 것을 느꼈습니다.
- 또한 본인의 유저 정보는 확실히 서버 상태가 아니라고 생각하게 되었습니다. 고로 업데이트 시에 값을 반환받고 해당 부분만 zustand store에 값을 바꿔주면 될 듯 합니다.
- 우선 토큰이 있는 경우만 자신의 유저 정보를 가져오도록 구현했는데요. 새로 가입된 경우까지는 정상 작동하는 것 확인했는데, 유저 업데이트 등에 대해서도 작업이 필요한 상황입니다.
- 추가로 expo go 앱이 뭔가(?) 달라진 느낌이라;; 이 부분도 제 수정사항 때문인지 좀 파악한 후에 머지하도록 하겠습니다. 
<br><br>

## 📎 커밋 범위 링크

<br><br>
