### PR TITLE
feat: 첫 페이지 뒤로가기 처리 & 알림 분기 처리

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useImageUpload } from './useImageUpload';
 export { useFeedList } from './useFeedList';
 export { useFeedWrite } from './useFeedWrite';
 export { useTimer } from './useTimer';
+export { useBackButton } from './useBackButton';

--- a/src/hooks/useBackButton.ts
+++ b/src/hooks/useBackButton.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { ToastAndroid, BackHandler } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
+
+export const useBackButton = () => {
+  const isFocused = useIsFocused();
+  const [isToastVisible, setIsToastVisible] = useState(false);
+
+  useEffect(() => {
+    const backAction = () => {
+      if (!isFocused) return;
+      if (isToastVisible) {
+        BackHandler.exitApp();
+        return true; // 기본 뒤로 가기 액션을 막음
+      } else {
+        showToast();
+        return true;
+      }
+    };
+    const backHandler = BackHandler.addEventListener('hardwareBackPress', backAction);
+
+    return () => backHandler.remove();
+  }, [isFocused, isToastVisible]);
+
+  const showToast = () => {
+    setIsToastVisible(true);
+    ToastAndroid.showWithGravity(
+      '앱을 끄려면 한 번 더 눌러주세요.',
+      ToastAndroid.SHORT,
+      ToastAndroid.BOTTOM
+    );
+
+    setTimeout(() => {
+      setIsToastVisible(false);
+    }, 3000);
+  };
+};

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,37 +1,45 @@
 import { useEffect, useState } from 'react';
 import { NotificationRepository } from '@/api';
+import { useUserStore } from '@/store';
+import { useQuery } from '@tanstack/react-query';
 import * as Linking from 'expo-linking';
 import * as Notifications from 'expo-notifications';
 import { registerForPushNotificationsAsync } from '@/utils';
 
 export default function useNotification() {
   const [expoPushToken, setExpoPushToken] = useState('');
+  const update = useUserStore((state) => state.update);
 
   const prefix = Linking.createURL('/'); // path 앞부분
 
   const registerToken = async () => {
-    try {
-      const token = await registerForPushNotificationsAsync();
-      if (token) {
-        setExpoPushToken(token);
-        NotificationRepository.registerToken({ token });
-      }
-    } catch (e) {
-      console.log(e);
+    const token = await registerForPushNotificationsAsync();
+    if (token) {
+      setExpoPushToken(token);
+      NotificationRepository.registerToken({ token });
     }
+    return token;
   };
-  useEffect(() => {
-    registerToken();
-  }, []);
+
+  useQuery({
+    queryKey: ['notifications'],
+    queryFn: registerToken,
+  });
 
   useEffect(() => {
     const backgroundListener = Notifications.addNotificationResponseReceivedListener((response) => {
       // 🔥 푸시 알림의 데이터 가져오기
       const data = response.notification.request.content.data;
-      if (data.feedId) {
-        const deepLinkUrl = `${prefix}feeds/${data.feedId}`;
-        Linking.openURL(deepLinkUrl);
+      if (data?.type === 'AUTHORIZATION') {
+        if (data?.isCertificated) {
+          update({ isCertificated: data?.isCertificated });
+        }
       }
+      if (data?.type === 'FEED')
+        if (data?.feedId) {
+          const deepLinkUrl = `${prefix}feeds/${data.feedId}`;
+          Linking.openURL(deepLinkUrl);
+        }
     });
 
     return () => {

--- a/src/screens/chat/RoomListScreen.tsx
+++ b/src/screens/chat/RoomListScreen.tsx
@@ -1,6 +1,7 @@
 import { TouchableOpacity, View } from 'react-native';
 import { RoomRepository } from '@/api';
 import { InnerLayout, Layout, MyText, RoomList } from '@/components';
+import { useBackButton } from '@/hooks';
 import { ChatStackParamList, FeedStackParamList } from '@/navigation/navigationRef';
 import { Room } from '@/types/RoomDTO';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -31,6 +32,8 @@ export default function RoomListScreen({ navigation }: RoomListNavigationProps) 
   const handlePressRoom = (room: Room) => {
     navigation.navigate('ChatRoom', { ...room });
   };
+
+  useBackButton();
 
   return (
     <Layout

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { feedKeys, FeedRepository } from '@/api';
 import { Button, CategoryPager, FeedList, InnerLayout, Layout } from '@/components';
-import { useFeedList } from '@/hooks';
+import { useFeedList, useBackButton } from '@/hooks';
 import { FeedStackParamList } from '@/navigation/navigationRef';
 import { useModalStore, useUserStore } from '@/store';
 import LogoIcon from '@assets/icons/logo.svg';
@@ -43,6 +43,8 @@ export default function HomeScreen({ navigation, route }: FeedHomeScreenProps) {
 
   const insets = useSafeAreaInsets();
   const writeButtonPosition = isAndroid ? insets.bottom + 80 : insets.bottom + 40;
+
+  useBackButton();
 
   return (
     <Layout

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { View, TouchableOpacity, Image } from 'react-native';
 import { AuthRepository, UserRepository } from '@/api';
 import { InnerLayout, Layout, MyText } from '@/components';
+import { useBackButton } from '@/hooks';
 import { MyPageStackParamList } from '@/navigation/navigationRef';
 import { TokenService } from '@/service';
 import { useUserStore } from '@/store';
@@ -83,6 +84,8 @@ export default function MyPageScreen({ navigation }: MyPageScreenProps) {
   const handleNotification = () => {
     console.log('notification pressed!');
   };
+
+  useBackButton();
 
   return (
     <Layout


### PR DESCRIPTION
## 📌 관련 이슈

<br><br>

## 🛠️ 작업 내용
- 각 탭의 첫 페이지에서 뒤로가기 시에 3초간 팝업이 뜨고, 3초 안에 한번 더 뒤로가기 클릭 시 앱이 꺼집니다.
- 백엔드에서 알림에 넣어줄 data 및 type을 분기 처리 하였습니다.
<br><br>

## 🎯 리뷰 포인트

<br><br>

## 📎 커밋 범위 링크

<br><br>
